### PR TITLE
Modernize stack: Eleventy 3, Alpine 3, Tailwind 4 (+ hero button fix)

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -9,8 +9,7 @@ module.exports = function (eleventyConfig) {
   // Disable automatic use of your .gitignore
   eleventyConfig.setUseGitIgnore(false);
 
-  // Merge data instead of overriding
-  eleventyConfig.setDataDeepMerge(true);
+  // (Eleventy 3 always deep-merges data; setDataDeepMerge was removed.)
 
   eleventyConfig.addGlobalData("permalink", () => {
     return (data) => `${data.page.filePathStem}.${data.page.outputFileExtension}`;

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -55,7 +55,7 @@ module.exports = function (eleventyConfig) {
   // Copy Static Files to /_Site
   eleventyConfig.addPassthroughCopy({
     "./src/admin/config.yml": "./admin/config.yml",
-    "./node_modules/alpinejs/dist/alpine.js": "./static/js/alpine.js"
+    "./node_modules/alpinejs/dist/cdn.min.js": "./static/js/alpine.js"
   });
 
   // Copy our own static JS (suggest-edit.js, etc.) to /_site/static/js

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,6 +2,10 @@
   publish = "_site"
   command = "npm run build"
 
+[build.environment]
+  # Eleventy 3 needs Node >= 18 and Tailwind 4 needs Node >= 20.
+  NODE_VERSION = "20"
+
 [functions]
   directory = "netlify/functions"
   node_bundler = "esbuild"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@11ty/eleventy": "^3.1.6",
     "@11ty/eleventy-plugin-syntaxhighlight": "^5.0.2",
     "@tailwindcss/typography": "^0.3.1",
-    "alpinejs": "^2.6.0",
+    "alpinejs": "^3.15.12",
     "browser-sync": "^2.26.14",
     "cross-env": "^7.0.2",
     "cssnano": "^4.1.10",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "devDependencies": {
     "@11ty/eleventy": "^3.1.6",
     "@11ty/eleventy-plugin-syntaxhighlight": "^5.0.2",
-    "@tailwindcss/typography": "^0.3.1",
+    "@tailwindcss/postcss": "^4.3.3",
+    "@tailwindcss/typography": "^0.5.20",
     "alpinejs": "^3.15.12",
     "browser-sync": "^2.26.14",
     "cross-env": "^7.0.2",
@@ -22,12 +23,11 @@
     "npm-run-all": "^4.1.5",
     "postcss-cli": "^8.3.1",
     "prismjs": "^1.21.0",
-    "tailwindcss": "^2.0.2"
+    "tailwindcss": "^4.3.3"
   },
   "dependencies": {
     "@netlify/blobs": "^10.7.9",
     "@octokit/app": "^16.1.2",
-    "autoprefixer": "^10.1.0",
     "postcss": "^8.2.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "https": "cd _site && http-server -g -S -C ../localhost+2.pem -K ../localhost+2-key.pem -c-1 --cors"
   },
   "devDependencies": {
-    "@11ty/eleventy": "^2.0.1",
-    "@11ty/eleventy-plugin-syntaxhighlight": "^3.0.1",
+    "@11ty/eleventy": "^3.1.6",
+    "@11ty/eleventy-plugin-syntaxhighlight": "^5.0.2",
     "@tailwindcss/typography": "^0.3.1",
     "alpinejs": "^2.6.0",
     "browser-sync": "^2.26.14",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,13 +1,8 @@
 module.exports = {
-  plugins: [
-    require(`tailwindcss`)(`./tailwind.config.js`),
-    require(`autoprefixer`),
+  plugins: {
+    "@tailwindcss/postcss": {},
     ...(process.env.NODE_ENV === "production"
-      ? [
-          require(`cssnano`)({
-            preset: "default",
-          }),
-        ]
-      : []),
-  ],
+      ? { cssnano: { preset: "default" } }
+      : {}),
+  },
 };

--- a/src/_includes/partials/email-subscriber.html
+++ b/src/_includes/partials/email-subscriber.html
@@ -1,19 +1,13 @@
-<div class="flex flex-col lg:flex-row lg:self-end lg:justify-end">
-  <div>
-    <div>
-      <form
-      class="flex flex-col lg:block"
-      action="https://buttondown.email/api/emails/embed-subscribe/trailangeles"
-      method="post"
-      target="popupwindow"
-      onsubmit="window.open('https://buttondown.email/trailangeles', 'popupwindow')"
-      class="embeddable-buttondown-form"
-    >
-        <input type="email" class="p-3 tracking-wide bg-white text-green-900 font-extralight" name="email" id="bd-email" placeholder="Enter your email"/>
-        <input type="hidden" value="1" name="embed" />
-        <input type="submit" class="p-3 leading-7 tracking-wide text-left text-green-800 bg-yellow-200 font-extralight lg:text-center" value="Subscribe" />
-      </form>
-    </div>
-  </div>
-</div>
-
+<form
+  class="flex flex-col gap-3 sm:flex-row sm:max-w-md"
+  action="https://buttondown.email/api/emails/embed-subscribe/trailangeles"
+  method="post"
+  target="popupwindow"
+  onsubmit="window.open('https://buttondown.email/trailangeles', 'popupwindow')"
+>
+  <input type="email" name="email" id="bd-email" placeholder="Enter your email"
+    class="flex-1 px-4 py-3 tracking-wide text-green-900 bg-white rounded-lg font-extralight" />
+  <input type="hidden" value="1" name="embed" />
+  <input type="submit" value="Subscribe"
+    class="px-6 py-3 font-black tracking-wide text-green-900 uppercase transition rounded-lg cursor-pointer bg-yellow-200 hover:bg-white" />
+</form>

--- a/src/_includes/partials/email-subscriber.html
+++ b/src/_includes/partials/email-subscriber.html
@@ -9,7 +9,7 @@
       onsubmit="window.open('https://buttondown.email/trailangeles', 'popupwindow')"
       class="embeddable-buttondown-form"
     >
-        <input type="email" class="p-3 tracking-wide font-extralight" name="email" id="bd-email" placeholder="Enter your email"/>
+        <input type="email" class="p-3 tracking-wide bg-white text-green-900 font-extralight" name="email" id="bd-email" placeholder="Enter your email"/>
         <input type="hidden" value="1" name="embed" />
         <input type="submit" class="p-3 leading-7 tracking-wide text-left text-green-800 bg-yellow-200 font-extralight lg:text-center" value="Subscribe" />
       </form>

--- a/src/_includes/partials/group-highlights.html
+++ b/src/_includes/partials/group-highlights.html
@@ -7,7 +7,7 @@
                 <a href="/volunteer-groups/{{org.slug}}" alt="{{org.name}}">
                     <img style="height: 160px; width: 100%; object-fit: cover;" src="{{org.photo}}">
                 </a>
-                <div class="p-5 h-50 lg:h-64 md:h-40 {{ background.next() }} flex flex-col justify-between">
+                <div class="p-5 lg:h-64 md:h-40 {{ background.next() }} flex flex-col justify-between">
                     <h3 class="font-extrabold tracking-wide text-white uppercase">{{org.name}}</h3>
                     <h4 class="font-serif text-sm font-light leading-6 tracking-wide text-white">{{org.description | truncate(100)}}</h4>
                     <a class="self-end float-right p-1 text-xl font-extrabold text-green-900 uppercase bg-yellow-200 rounded-full go-button" href="/volunteer-groups/{{org.slug}}">Go</a>
@@ -17,7 +17,7 @@
         <a
             href="/volunteer-groups/" 
             target="_blank"
-            class="flex justify-start lg:justify-end lg:p-5 lg:bg-green-900 lg:h-50"
+            class="flex justify-start lg:justify-end lg:p-5 lg:bg-green-900"
         >
             <div class="self-center" style="margin-right: -3.75rem">
                 <div class="float-right w-10 overflow-hidden">

--- a/src/_includes/partials/group-highlights.html
+++ b/src/_includes/partials/group-highlights.html
@@ -1,30 +1,24 @@
-<div class="grid w-full grid-cols-1 my-4 lg:my-10 lg:mb-10 lg:grid-cols-4 lg:mx-0">
-    {% if orgs.organizations %}
-    {% set orgs = orgs.organizations %}
-        {% set background = cycler("bg-green-900", "bg-green-700", "bg-green-600") %}
-        {% for org in orgs.slice(0,3) %}
-            <div class="pt-2 lg:p-0">
-                <a href="/volunteer-groups/{{org.slug}}" alt="{{org.name}}">
-                    <img style="height: 160px; width: 100%; object-fit: cover;" src="{{org.photo}}">
-                </a>
-                <div class="p-5 lg:h-64 md:h-40 {{ background.next() }} flex flex-col justify-between">
-                    <h3 class="font-extrabold tracking-wide text-white uppercase">{{org.name}}</h3>
-                    <h4 class="font-serif text-sm font-light leading-6 tracking-wide text-white">{{org.description | truncate(100)}}</h4>
-                    <a class="self-end float-right p-1 text-xl font-extrabold text-green-900 uppercase bg-yellow-200 rounded-full go-button" href="/volunteer-groups/{{org.slug}}">Go</a>
-                </div>
-            </div>
-        {% endfor %}
-        <a
-            href="/volunteer-groups/" 
-            target="_blank"
-            class="flex justify-start lg:justify-end lg:p-5 lg:bg-green-900"
-        >
-            <div class="self-center" style="margin-right: -3.75rem">
-                <div class="float-right w-10 overflow-hidden">
-                    <div class="text-2xl text-green-900 origin-top-left transform rotate-45 bg-yellow-200" style="height: 52px"></div>
-                </div>
-                <div class="float-right px-6 py-3 text-lg font-medium leading-7 tracking-wide text-green-900 bg-yellow-200">View All Groups</div>
-            </div>
-        </a>
-    {% endif %}
+<div class="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
+  {% if orgs.organizations %}
+  {% set orgs = orgs.organizations %}
+    {% for org in orgs.slice(0,3) %}
+      <a href="/volunteer-groups/{{ org.slug }}" class="flex flex-col overflow-hidden transition bg-white shadow-sm group rounded-2xl hover:shadow-lg">
+        <div class="overflow-hidden h-44">
+          {% if org.photo %}
+            <img src="{{ org.photo }}" alt="{{ org.name }}" class="object-cover w-full h-full transition duration-300 group-hover:scale-105">
+          {% else %}
+            <div class="w-full h-full bg-green-300"></div>
+          {% endif %}
+        </div>
+        <div class="flex flex-col flex-1 p-6">
+          <h3 class="text-lg font-black tracking-wide text-green-900 uppercase">{{ org.name }}</h3>
+          <p class="flex-1 mt-2 font-serif text-sm leading-relaxed text-green-900/80">{{ org.description | truncate(110) }}</p>
+          <span class="inline-flex items-center gap-1 mt-4 font-black tracking-wide text-green-700 uppercase group-hover:text-green-900">
+            Learn more
+            <svg class="w-4 h-4 transition group-hover:translate-x-1" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7"/></svg>
+          </span>
+        </div>
+      </a>
+    {% endfor %}
+  {% endif %}
 </div>

--- a/src/_includes/partials/mailer.html
+++ b/src/_includes/partials/mailer.html
@@ -1,10 +1,12 @@
-<div class="pt-8 pb-8 bg-green-700 lg:py-12">
-  <div class="container flex flex-col lg:justify-between subscriber-background">
-    <div>
-      <h1 class="pr-8 text-4xl font-black text-white uppercase lg:p-0 lg:text-7xl lg:table-caption">
-        Get monthly trail updates
-      </h2>
+<section class="bg-green-800">
+  <div class="container px-4 mx-auto py-14 md:py-20">
+    <div class="max-w-2xl">
+      <p class="mb-2 text-sm font-black tracking-widest text-yellow-200 uppercase">Newsletter</p>
+      <h2 class="text-3xl font-black leading-tight text-white uppercase md:text-5xl">Get monthly trail updates</h2>
+      <p class="mt-4 font-serif text-green-300 md:text-lg">Trail conditions, volunteer opportunities, and news from the Angeles National Forest — straight to your inbox.</p>
+      <div class="mt-6">
+        {% include "./email-subscriber.html" %}
+      </div>
     </div>
-    {% include "./email-subscriber.html" %}
   </div>
-</div>
+</section>

--- a/src/_includes/partials/mailer.html
+++ b/src/_includes/partials/mailer.html
@@ -2,7 +2,7 @@
   <div class="container px-4 mx-auto py-14 md:py-20">
     <div class="max-w-2xl">
       <p class="mb-2 text-sm font-black tracking-widest text-yellow-200 uppercase">Newsletter</p>
-      <h2 class="text-3xl font-black leading-tight text-white uppercase md:text-5xl">Get monthly trail updates</h2>
+      <h2 class="text-3xl font-black leading-tight text-white uppercase md:text-5xl">Join Our Newsletter</h2>
       <p class="mt-4 font-serif text-green-300 md:text-lg">Trail conditions, volunteer opportunities, and news from the Angeles National Forest — straight to your inbox.</p>
       <div class="mt-6">
         {% include "./email-subscriber.html" %}

--- a/src/_includes/partials/navbar.html
+++ b/src/_includes/partials/navbar.html
@@ -14,7 +14,7 @@
         </button>
 
         <!--Menu-->
-        <div class="flex-grow w-full text-center lg:flex lg:items-center lg:w-auto " :class="{ 'block shadow-3xl': isOpen, 'hidden': !isOpen }" @click.outside="isOpen = false" x-show="true" x-transition>
+        <div class="grow w-full text-center lg:flex lg:items-center lg:w-auto " :class="{ 'block shadow-3xl': isOpen, 'hidden': !isOpen }" @click.outside="isOpen = false" x-show="true" x-transition>
 
             {% if navigation.items %}
                 <ul class="items-center justify-end flex-1 pt-6 lg:pt-0 list-reset lg:flex">

--- a/src/_includes/partials/navbar.html
+++ b/src/_includes/partials/navbar.html
@@ -14,7 +14,7 @@
         </button>
 
         <!--Menu-->
-        <div class="flex-grow w-full text-center lg:flex lg:items-center lg:w-auto " :class="{ 'block shadow-3xl': isOpen, 'hidden': !isOpen }" @click.away="isOpen = false" x-show.transition="true">
+        <div class="flex-grow w-full text-center lg:flex lg:items-center lg:w-auto " :class="{ 'block shadow-3xl': isOpen, 'hidden': !isOpen }" @click.outside="isOpen = false" x-show="true" x-transition>
 
             {% if navigation.items %}
                 <ul class="items-center justify-end flex-1 pt-6 lg:pt-0 list-reset lg:flex">

--- a/src/_includes/partials/navbar.html
+++ b/src/_includes/partials/navbar.html
@@ -14,7 +14,7 @@
         </button>
 
         <!--Menu-->
-        <div class="grow w-full text-center lg:flex lg:items-center lg:w-auto " :class="{ 'block shadow-3xl': isOpen, 'hidden': !isOpen }" @click.outside="isOpen = false" x-show="true" x-transition>
+        <div class="grow w-full text-center lg:flex lg:items-center lg:w-auto" :class="isOpen ? 'block' : 'hidden'">
 
             {% if navigation.items %}
                 <ul class="items-center justify-end flex-1 pt-6 lg:pt-0 list-reset lg:flex">

--- a/src/_includes/partials/slider.html
+++ b/src/_includes/partials/slider.html
@@ -3,7 +3,7 @@
     <source src="/static/img/winter-san-gabriels.webm" type="video/mp4" />
   </video>
   <!-- Scrim to keep the white text legible over the bright video -->
-  <div class="absolute inset-0 bg-black bg-opacity-40" aria-hidden="true"></div>
+  <div class="absolute inset-0 bg-black/40" aria-hidden="true"></div>
   <div class="z-10 center-container">
     <h2 class="pt-10 text-lg font-extrabold text-center text-yellow-200 uppercase lg:pt-20 lg:text-2xl md:text-xl offset-underline">Trail Angeles</h2>
     <p class="w-3/4 pt-4 pb-12 font-serif text-sm leading-tight text-center text-white md:text-base md:pt-4 lg:pt-4 lg:w-1/2 md:text-large" style="margin: 0 auto;">This site was created by volunteers for volunteers, hikers and anyone who uses the Angeles National Forest. Much of the forest is maintained through volunteer efforts. We welcome you to volunteer to keep our forest accessible to everyone.</p>

--- a/src/_includes/partials/slider.html
+++ b/src/_includes/partials/slider.html
@@ -7,6 +7,6 @@
   <div class="z-10 center-container">
     <h2 class="pt-10 text-lg font-extrabold text-center text-yellow-200 uppercase lg:pt-20 lg:text-2xl md:text-xl offset-underline">Trail Angeles</h2>
     <p class="w-3/4 pt-4 pb-12 font-serif text-sm leading-tight text-center text-white md:text-base md:pt-4 lg:pt-4 lg:w-1/2 md:text-large" style="margin: 0 auto;">This site was created by volunteers for volunteers, hikers and anyone who uses the Angeles National Forest. Much of the forest is maintained through volunteer efforts. We welcome you to volunteer to keep our forest accessible to everyone.</p>
-    <a href="/posts/" class="px-4 py-2 text-lg font-light leading-7 tracking-wide text-left text-green-800 bg-yellow-200 md:px-6 md:py-3 lg:text-center">Learn more</a>
+    <a href="/posts/" style="text-shadow: none;" class="px-4 py-2 text-lg font-light leading-7 tracking-wide text-left text-green-800 bg-yellow-200 md:px-6 md:py-3 lg:text-center">Learn more</a>
   </div>
 </div>

--- a/src/_includes/partials/slider.html
+++ b/src/_includes/partials/slider.html
@@ -1,12 +1,16 @@
-<div class="relative overflow-hidden">
-  <video class="object-cover w-full" autoplay="autoplay" muted loop playsinline>
+<section class="relative overflow-hidden">
+  <video class="object-cover w-full h-[70vh] min-h-[26rem]" autoplay="autoplay" muted loop playsinline>
     <source src="/static/img/winter-san-gabriels.webm" type="video/mp4" />
   </video>
   <!-- Scrim to keep the white text legible over the bright video -->
-  <div class="absolute inset-0 bg-black/40" aria-hidden="true"></div>
-  <div class="z-10 center-container">
-    <h2 class="pt-10 text-lg font-extrabold text-center text-yellow-200 uppercase lg:pt-20 lg:text-2xl md:text-xl offset-underline">Trail Angeles</h2>
-    <p class="w-3/4 pt-4 pb-12 font-serif text-sm leading-tight text-center text-white md:text-base md:pt-4 lg:pt-4 lg:w-1/2 md:text-large" style="margin: 0 auto;">This site was created by volunteers for volunteers, hikers and anyone who uses the Angeles National Forest. Much of the forest is maintained through volunteer efforts. We welcome you to volunteer to keep our forest accessible to everyone.</p>
-    <a href="/posts/" style="text-shadow: none;" class="px-4 py-2 text-lg font-light leading-7 tracking-wide text-left text-green-800 bg-yellow-200 md:px-6 md:py-3 lg:text-center">Learn more</a>
+  <div class="absolute inset-0 bg-black/45" aria-hidden="true"></div>
+  <div class="z-10 px-4 center-container">
+    <p class="mb-3 text-sm font-black tracking-widest text-yellow-200 uppercase md:text-base">Angeles National Forest</p>
+    <h1 class="max-w-3xl text-4xl font-black leading-none tracking-tight text-white uppercase md:text-6xl">Trail Angeles</h1>
+    <p class="max-w-xl mt-5 font-serif leading-relaxed text-center text-white md:text-lg">Created by volunteers, for volunteers, hikers, and everyone who uses the Angeles National Forest. Help keep our forest accessible to all.</p>
+    <div class="flex flex-col gap-3 mt-8 sm:flex-row sm:justify-center">
+      <a href="/volunteer-groups/" style="text-shadow: none;" class="px-6 py-3 font-black tracking-wide text-green-900 uppercase transition rounded-lg bg-yellow-200 hover:bg-white">Find a volunteer group</a>
+      <a href="/posts/" style="text-shadow: none;" class="px-6 py-3 font-black tracking-wide text-white uppercase transition border-2 border-white rounded-lg hover:bg-white hover:text-green-900">Learn more</a>
+    </div>
   </div>
-</div>
+</section>

--- a/src/_includes/partials/slider.html
+++ b/src/_includes/partials/slider.html
@@ -9,8 +9,8 @@
     <h1 class="max-w-3xl text-4xl font-black leading-none tracking-tight text-white uppercase md:text-6xl">Trail Angeles</h1>
     <p class="max-w-xl mt-5 font-serif leading-relaxed text-center text-white md:text-lg">Created by volunteers, for volunteers, hikers, and everyone who uses the Angeles National Forest. Help keep our forest accessible to all.</p>
     <div class="flex flex-col gap-3 mt-8 sm:flex-row sm:justify-center">
-      <a href="/volunteer-groups/" style="text-shadow: none;" class="px-6 py-3 font-black tracking-wide text-green-900 uppercase transition rounded-lg bg-yellow-200 hover:bg-white">Find a volunteer group</a>
-      <a href="/posts/" style="text-shadow: none;" class="px-6 py-3 font-black tracking-wide text-white uppercase transition border-2 border-white rounded-lg hover:bg-white hover:text-green-900">Learn more</a>
+      <a href="/volunteer-groups/" style="text-shadow: none;" class="inline-flex items-center justify-center px-6 py-3 font-black tracking-wide text-green-900 uppercase transition border-2 border-transparent rounded-lg bg-yellow-200 hover:bg-white">Find a volunteer group</a>
+      <a href="/posts/about-us" style="text-shadow: none;" class="inline-flex items-center justify-center px-6 py-3 font-black tracking-wide text-white uppercase transition border-2 border-white rounded-lg hover:bg-white hover:text-green-900">Learn more</a>
     </div>
   </div>
 </section>

--- a/src/_includes/partials/suggest-edit.html
+++ b/src/_includes/partials/suggest-edit.html
@@ -1,77 +1,112 @@
-{# Reusable public "Suggest an edit" form.
-   Set `editCollection` (e.g. "orgs") and `editTarget` (the record object)
-   before including. Posts changed fields to /api/submit-edit, which opens a PR. #}
+{# Reusable public "Suggest an edit" form. Set `editCollection` (e.g. "orgs")
+and `editTarget` (the record object) before including. Posts changed fields to
+/api/submit-edit, which opens a PR. #}
 
-<style>[x-cloak]{display:none !important}</style>
-<script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>
+<style>
+  [x-cloak] {
+    display: none !important;
+  }
+</style>
+<script
+  src="https://challenges.cloudflare.com/turnstile/v0/api.js"
+  async
+  defer
+></script>
 <script src="/static/js/suggest-edit.js"></script>
 
-{% set fieldDefs = [
-  { name: "name", label: "Name", type: "text" },
-  { name: "contactName", label: "Contact name", type: "text" },
-  { name: "contactEmail", label: "Contact email", type: "text" },
-  { name: "website", label: "Website", type: "text" },
-  { name: "facebook", label: "Facebook URL", type: "text" },
-  { name: "instagram", label: "Instagram URL", type: "text" },
-  { name: "description", label: "Description", type: "textarea" }
-] %}
+{% set fieldDefs = [ { name: "name", label: "Name", type: "text" }, { name:
+"contactName", label: "Contact name", type: "text" }, { name: "contactEmail",
+label: "Contact email", type: "text" }, { name: "website", label: "Website",
+type: "text" }, { name: "facebook", label: "Facebook URL", type: "text" }, {
+name: "instagram", label: "Instagram URL", type: "text" }, { name:
+"description", label: "Description", type: "textarea" } ] %} {% set cfg = {
+collection: editCollection, targetId: editTarget.id, initial: { name:
+editTarget.name or "", contactName: editTarget.contactName or "", contactEmail:
+editTarget.contactEmail or "", website: editTarget.website or "", facebook:
+editTarget.facebook or "", instagram: editTarget.instagram or "", description:
+editTarget.description or "" } } %}
 
-{% set cfg = {
-  collection: editCollection,
-  targetId: editTarget.id,
-  initial: {
-    name: editTarget.name or "",
-    contactName: editTarget.contactName or "",
-    contactEmail: editTarget.contactEmail or "",
-    website: editTarget.website or "",
-    facebook: editTarget.facebook or "",
-    instagram: editTarget.instagram or "",
-    description: editTarget.description or ""
-  }
-} %}
+<section class="border-t border-gray-200 bg-gray-100">
+  <div
+    class="container max-w-3xl px-4 mx-auto text-center py-14"
+    x-data="suggestEdit({{ cfg | dump | escape }})"
+  >
+    <h2 class="mb-2 text-xl font-black tracking-wide text-green-900 uppercase">
+      See something out of date?
+    </h2>
+    <p class="max-w-xl mx-auto mb-6 font-serif text-green-900">
+      Suggest a correction and a maintainer will review it before it goes live.
+    </p>
 
-<div class="container mx-auto my-16">
-  <div class="w-3/4 mx-auto" x-data="suggestEdit({{ cfg | dump | escape }})">
-    <button type="button" @click="open = !open"
-      class="px-6 py-3 font-black text-white uppercase transition bg-green-700 rounded hover:bg-green-800"
-      x-text="open ? 'Cancel' : 'Suggest an edit'"></button>
+    <button
+      type="button"
+      @click="open = !open"
+      class="px-6 py-3 font-black text-white uppercase transition bg-green-700 rounded-lg hover:bg-green-800"
+      x-text="open ? 'Cancel' : 'Suggest an edit'"
+    ></button>
 
-    <form x-ref="form" x-show="open" x-cloak @submit.prevent="submit()"
-      class="p-6 mt-4 bg-gray-100 rounded-lg">
-      <p class="mb-6 font-serif text-green-900">
-        See something out of date? Suggest a correction below. A maintainer reviews
-        every suggestion before it goes live — <strong>no GitHub or any account needed</strong>.
-      </p>
-
+    <form
+      x-ref="form"
+      x-show="open"
+      x-cloak
+      @submit.prevent="submit()"
+      class="p-6 mt-6 text-left bg-white shadow-sm rounded-2xl md:p-8"
+    >
       <template x-if="submitted">
-        <p class="p-4 font-bold text-green-800 bg-green-100 rounded" x-text="message"></p>
+        <p
+          class="p-4 font-bold text-green-900 rounded-lg bg-yellow-200"
+          x-text="message"
+        ></p>
       </template>
 
       <div x-show="!submitted">
         {% for f in fieldDefs %}
-          <label class="block mt-4 mb-1 font-bold text-green-900">{{ f.label }}</label>
-          {% if f.type == "textarea" %}
-            <textarea x-model="fields.{{ f.name }}" rows="5"
-              class="w-full p-2 text-green-900 bg-white border border-green-300 rounded"></textarea>
-          {% else %}
-            <input type="text" x-model="fields.{{ f.name }}"
-              class="w-full p-2 text-green-900 bg-white border border-green-300 rounded">
-          {% endif %}
-        {% endfor %}
+        <label class="block mt-4 mb-1 font-bold text-green-900"
+          >{{ f.label }}</label
+        >
+        {% if f.type == "textarea" %}
+        <textarea
+          x-model="fields.{{ f.name }}"
+          rows="5"
+          class="w-full p-2 text-green-900 bg-white border border-green-300 rounded"
+        ></textarea>
+        {% else %}
+        <input
+          type="text"
+          x-model="fields.{{ f.name }}"
+          class="w-full p-2 text-green-900 bg-white border border-green-300 rounded"
+        />
+        {% endif %} {% endfor %}
 
-        <label class="block mt-4 mb-1 font-bold text-green-900">Your email (optional)</label>
-        <input type="email" x-model="email" placeholder="So a maintainer can follow up"
-          class="w-full p-2 text-green-900 bg-white border border-green-300 rounded">
+        <label class="block mt-4 mb-1 font-bold text-green-900"
+          >Your email (optional)</label
+        >
+        <input
+          type="email"
+          x-model="email"
+          placeholder="So a maintainer can follow up"
+          class="w-full p-2 text-green-900 bg-white border border-green-300 rounded"
+        />
 
-        <div class="my-4 cf-turnstile" data-sitekey="{{ turnstile.sitekey }}" data-action="turnstile-spin-v2"></div>
+        <div
+          class="my-4 cf-turnstile"
+          data-sitekey="{{ turnstile.sitekey }}"
+          data-action="turnstile-spin-v2"
+        ></div>
 
-        <button type="submit" :disabled="submitting"
-          class="px-6 py-3 font-black text-white uppercase bg-green-700 rounded hover:bg-green-800 disabled:opacity-50"
-          x-text="submitting ? 'Submitting…' : 'Submit suggestion'"></button>
+        <button
+          type="submit"
+          :disabled="submitting"
+          class="px-6 py-3 font-black text-white uppercase bg-green-700 rounded-lg hover:bg-green-800 disabled:opacity-50"
+          x-text="submitting ? 'Submitting…' : 'Submit suggestion'"
+        ></button>
 
-        <p x-show="message && !submitted" x-text="message"
-          :class="error ? 'text-red-700' : 'text-green-700'" class="mt-3 font-bold"></p>
+        <p
+          x-show="message && !submitted"
+          x-text="message"
+          class="mt-3 font-bold text-yellow-500"
+        ></p>
       </div>
     </form>
   </div>
-</div>
+</section>

--- a/src/index.html
+++ b/src/index.html
@@ -5,21 +5,18 @@ path: Home
 ---*/
 {% include "./_includes/partials/slider.html" %}
 
-<!-- <div class="container flex flex-col justify-center pt-8 pb-4 mx-auto lg:pb-11">
-  <h2 class="font-sans text-3xl font-black text-green-800 uppercase border-b border-green-800 lg:text-4xl">Upcoming events</h2>
-  {% include "./_includes/partials/event-highlights.html" %}
-</div> -->
-
-<div class="flex flex-col justify-center pb-8 mx-auto bg-gray-100 pt-14">
-  <div class="container">
-    <h2 class="font-sans text-3xl font-black text-green-800 uppercase border-b border-green-800 lg:text-4xl">Featured groups</h2>
+<!-- Featured groups -->
+<section class="bg-gray-100">
+  <div class="container px-4 mx-auto py-14 md:py-20">
+    <div class="flex flex-wrap items-end justify-between gap-4 mb-8">
+      <div>
+        <p class="mb-1 text-sm font-black tracking-widest text-green-700 uppercase">Get involved</p>
+        <h2 class="text-3xl font-black tracking-tight text-green-900 uppercase md:text-4xl">Featured groups</h2>
+      </div>
+      <a href="/volunteer-groups/" class="px-5 py-2.5 font-black tracking-wide text-green-900 uppercase transition rounded-lg bg-yellow-200 hover:bg-green-700 hover:text-white">All groups</a>
+    </div>
     {% include "./_includes/partials/group-highlights.html" %}
   </div>
-</div>
-<!-- 
-<div class="container flex flex-col justify-center pt-8 pb-4 mx-auto lg:pb-11">
-  <h2 class="font-sans text-3xl font-black text-green-800 uppercase border-b border-green-800 lg:text-4xl">Featured places</h2>
-  {% include "./_includes/partials/place-highlights.html" %}
-</div> -->
+</section>
 
 {% include "./_includes/partials/mailer.html" %}

--- a/src/newsletter.html
+++ b/src/newsletter.html
@@ -23,13 +23,13 @@ path: Newsletter
         height="100%"
       />
     </div>
-    <div class="flex flex-col flex-grow w-1/4 flex-stretch">
-      <div class="flex-grow flex-shrink bg-green-700 p-7 flex-basis">
+    <div class="flex flex-col grow w-1/4 flex-stretch">
+      <div class="grow shrink bg-green-700 p-7 flex-basis">
         <h3 class="text-xl font-extrabold text-white uppercase">
           October 2022 Edition
         </h3>
       </div>
-      <div class="flex-grow flex-shrink bg-green-400 p-7 flex-basis">
+      <div class="grow shrink bg-green-400 p-7 flex-basis">
         <h3 class="text-xl font-extrabold text-white uppercase">About</h3>
         <p class="text-white">
           This newsletter is issued bi-monthly.
@@ -49,7 +49,7 @@ path: Newsletter
           page.
         </p>
       </div>
-      <div class="flex-grow flex-shrink bg-green-700 p-7 flex-basis">
+      <div class="grow shrink bg-green-700 p-7 flex-basis">
         <h3 class="text-xl font-extrabold text-white uppercase">Staff</h3>
         <ul>
           <li class="text-sm text-white list-disc list-inside">
@@ -78,7 +78,7 @@ path: Newsletter
           again by issuing August 2021 ANF Volunteer Newsletter.
         </p>
       </div>
-      <div class="flex-grow flex-shrink bg-green-400 p-7 flex-basis">
+      <div class="grow shrink bg-green-400 p-7 flex-basis">
         <h3 class="text-xl font-extrabold text-white uppercase">Archives</h3>
         <ul class="text-white list-disc list-inside">
           <li>

--- a/src/places/place-pages.html
+++ b/src/places/place-pages.html
@@ -40,8 +40,8 @@ path: Places
             <div id="map" style="height: 400px; width: 100%;"></div>
         </div>
     </div>
-    <div class="flex flex-col flex-grow flex-stretch">
-        <div class="flex-grow flex-shrink bg-green-700 p-7 flex-basis">
+    <div class="flex flex-col grow flex-stretch">
+        <div class="grow shrink bg-green-700 p-7 flex-basis">
             <h3 class="text-white">
                 Status:
                 {% if place.status === true %}
@@ -51,7 +51,7 @@ path: Places
                 {% endif %}
             </h3>
         </div>
-        <div class="flex-grow flex-shrink bg-green-800 p-7 flex-basis">
+        <div class="grow shrink bg-green-800 p-7 flex-basis">
             <h3 class="font-black text-white uppercase">Maintained by:</h3>
         </div>
     </div>

--- a/src/static/css/tailwind.css
+++ b/src/static/css/tailwind.css
@@ -243,10 +243,6 @@ h3 {
   bottom: 3rem;
 }
 
-.hidden {
-  display: none;
-}
-
 .selected-filter {
   background-color: rgb(255, 230, 123);
 }

--- a/src/static/css/tailwind.css
+++ b/src/static/css/tailwind.css
@@ -1,11 +1,26 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
+@import "tailwindcss";
+@config "../../../tailwind.config.js";
+
+/* Preserve the pre-v4 default border color (Tailwind v4 defaults to currentColor) */
+@layer base {
+  *,
+  ::after,
+  ::before,
+  ::backdrop,
+  ::file-selector-button {
+    border-color: var(--color-gray-200, #f2f2f2);
+  }
+}
 
 /*Your Custom CSS Goes here*/
 
 h1 {
-  @apply text-4xl font-black lg:text-7xl;
+  @apply text-4xl font-black;
+}
+@media (min-width: 1024px) {
+  h1 {
+    @apply text-7xl;
+  }
 }
 
 h2 {

--- a/src/volunteer-groups/group-pages.html
+++ b/src/volunteer-groups/group-pages.html
@@ -8,62 +8,131 @@ permalink: "volunteer-groups/{{ group.slug }}/"
 path: Volunteer Groups
 ---*/
 
-<div class="bg-white">
-    <div class="yellow-triangle-corner">
-    </div>
-    <div class="container mx-auto">
-        <div class="w-3/4 py-10 mx-auto">
-            <h2 class="pt-6 pb-6 text-3xl font-black text-green-900 uppercase md:text-4xl">Volunteer with {{ group.name }}</h2>
-            <div id="group-photo" class="w-full mb-12 bg-blue-500 md:w-9/12 h-96">
-                {% if group.photo != nil %}
-                    <img class="object-cover w-full h-96" src="{{group.photo}}">
-                {% else %}
-                    <div class="w-full bg-yellow-500 h-96"></div>
-                {% endif %}
-            </div>
-            <!-- <h5 class="pt-10 pb-10 font-black text-green-900 uppercase">Last Updated 00/00/00</h5> -->
-            <ol>
-                <li class="font-serif leading-loose text-green-900">{{ group.description | markdown | safe }}</li><br>
-                <li class="font-serif leading-loose text-green-900">{{ group.requirements }}</li>
-            </ol>
-        </div>
-    </div>
-    </div>
+<!-- Breadcrumb -->
+<div class="bg-white border-b border-gray-200">
+  <div class="container px-4 py-4 mx-auto">
+    <a href="/volunteer-groups/" class="inline-flex items-center gap-2 text-sm font-black tracking-wide text-green-700 uppercase hover:text-green-900">
+      <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7"/></svg>
+      All volunteer groups
+    </a>
+  </div>
 </div>
 
-<div class="flex flex-col mt-2 bg-gray-100 flex-stretch md:flex-row">
-    <div class="w-full">
-        <div id="map" style="height: 400px; width: 100%;"></div>
-    </div>
-    <div class="flex flex-col grow flex-stretch">
-        <div class="grow shrink bg-green-700 p-7 flex-basis">
-            <h3 class="text-xl font-extrabold text-white uppercase">{{group.name}}</h3>
-            <ul class="text-white">
-                <li><span>E-mail: <a class="text-white" href="mailto:{{ group.contactEmail }}">{{group.contactName}}</a></li>
-                <li><a class="text-white underline hover:no-underline" href="{{ group.website }}">Website</a></li>
-                <li><a class="text-white underline hover:no-underline" href="{{ group.instagram }}">Instagram</a></li>
-                <li><a class="text-white underline hover:no-underline" href="{{ group.facebook }}">Facebook</a></li>
-            </ul>
+<!-- Hero -->
+<header class="relative flex items-end overflow-hidden bg-green-900 h-72 md:h-96">
+  {% if group.photo %}
+    <img class="absolute inset-0 object-cover w-full h-full" src="{{ group.photo }}" alt="{{ group.name }}">
+  {% endif %}
+  <div class="absolute inset-0" style="background: linear-gradient(to top, rgba(2,80,47,0.95) 0%, rgba(2,80,47,0.55) 45%, rgba(2,80,47,0.15) 100%);"></div>
+  <div class="relative w-full">
+    <div class="container px-4 pb-8 mx-auto md:pb-10">
+      <p class="mb-2 text-xs font-black tracking-widest text-yellow-200 uppercase md:text-sm">Volunteer group</p>
+      <h1 class="max-w-3xl text-4xl font-black leading-none tracking-tight text-white uppercase md:text-6xl">{{ group.name }}</h1>
+      {% if group.filters %}
+        <div class="flex flex-wrap gap-2 mt-5">
+          {% for groupfilter in group.filters %}
+          {% for filter in sortablefilters.filters %}
+          {% if groupfilter === filter.id %}
+            <span class="px-3 py-1 text-xs font-bold tracking-wide text-green-900 uppercase rounded-full bg-yellow-200">{{ filter.name }}</span>
+          {% endif %}
+          {% endfor %}
+          {% endfor %}
         </div>
-        <div class="grow shrink bg-green-800 p-7 flex-basis">
-            <h3 class="text-xl font-extrabold text-white uppercase">Places maintained</h3>
-                {% for groupplace in group.places %}
-                {% for place in places.places %}
-                {% if groupplace === place.id %}
-                    <a class="text-white" href="/places/{{place.slug}}">{{ place.name }} </span>
-                {% endif %}
-                {% endfor -%}
-                {% endfor -%}
-                    </div>
+      {% endif %}
     </div>
+  </div>
+</header>
+
+<!-- Body -->
+<div class="bg-gray-100">
+  <div class="container px-4 py-12 mx-auto lg:grid lg:grid-cols-3 lg:gap-10 lg:py-16">
+
+    <!-- Main column -->
+    <div class="lg:col-span-2">
+      <section class="p-6 bg-white shadow-sm rounded-2xl md:p-10">
+        <h2 class="mb-5 text-2xl font-black tracking-wide text-green-900 uppercase">About</h2>
+        <div class="font-serif leading-relaxed text-green-900 md:text-lg">
+          {{ group.description | markdown | safe }}
+        </div>
+        {% if group.requirements %}
+          <div class="p-5 mt-8 border-l-4 border-yellow-200 rounded-r-lg bg-gray-100">
+            <h3 class="mb-2 text-sm font-black tracking-widest text-green-700 uppercase">Good to know</h3>
+            <p class="font-serif leading-relaxed text-green-900">{{ group.requirements }}</p>
+          </div>
+        {% endif %}
+      </section>
+
+      {% if group.places %}
+      <section class="p-6 mt-8 bg-white shadow-sm rounded-2xl md:p-10">
+        <h2 class="mb-5 text-2xl font-black tracking-wide text-green-900 uppercase">Places maintained</h2>
+        <div class="flex flex-wrap gap-3">
+          {% for groupplace in group.places %}
+          {% for place in places.places %}
+          {% if groupplace === place.id %}
+            <a href="/places/{{ place.slug }}" class="inline-flex items-center gap-2 px-4 py-2 font-bold text-green-900 transition rounded-full bg-green-300/40 hover:bg-yellow-200">
+              <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M17.657 16.657L13.414 20.9a2 2 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"/><path stroke-linecap="round" stroke-linejoin="round" d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"/></svg>
+              {{ place.name }}
+            </a>
+          {% endif %}
+          {% endfor %}
+          {% endfor %}
+        </div>
+      </section>
+      {% endif %}
+    </div>
+
+    <!-- Sidebar: get involved -->
+    <aside class="mt-8 lg:mt-0">
+      <div class="overflow-hidden shadow-sm rounded-2xl lg:sticky lg:top-6">
+        <div class="p-6 bg-green-800 md:p-8">
+          <h2 class="text-xl font-black tracking-wide text-white uppercase">Get involved</h2>
+          <p class="mt-2 font-serif text-green-300">Reach out to {{ group.name }} to start volunteering.</p>
+
+          {% if group.contactEmail %}
+            <a href="mailto:{{ group.contactEmail }}" class="flex items-center justify-center w-full gap-2 px-4 py-3 mt-6 font-black tracking-wide text-green-900 uppercase transition rounded-lg bg-yellow-200 hover:bg-white">
+              <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/></svg>
+              Email to volunteer
+            </a>
+            {% if group.contactName %}
+              <p class="mt-3 text-sm text-center text-green-300">Contact: <span class="text-white">{{ group.contactName }}</span></p>
+            {% endif %}
+          {% endif %}
+        </div>
+
+        {% if group.website or group.instagram or group.facebook %}
+          <div class="divide-y divide-green-800 bg-green-700">
+            {% if group.website %}
+              <a href="{{ group.website }}" target="_blank" rel="noopener" class="flex items-center gap-3 px-6 py-4 font-bold text-white transition hover:bg-green-800">
+                <svg class="w-5 h-5 text-yellow-200 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/><path stroke-linecap="round" stroke-linejoin="round" d="M3.6 9h16.8M3.6 15h16.8M12 3a15 15 0 010 18 15 15 0 010-18z"/></svg>
+                Website
+              </a>
+            {% endif %}
+            {% if group.instagram %}
+              <a href="{{ group.instagram }}" target="_blank" rel="noopener" class="flex items-center gap-3 px-6 py-4 font-bold text-white transition hover:bg-green-800">
+                <svg class="w-5 h-5 text-yellow-200 shrink-0" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2.16c3.2 0 3.58.01 4.85.07 1.17.05 1.8.25 2.23.41.56.22.96.48 1.38.9.42.42.68.82.9 1.38.16.42.36 1.06.41 2.23.06 1.27.07 1.65.07 4.85s-.01 3.58-.07 4.85c-.05 1.17-.25 1.8-.41 2.23a3.7 3.7 0 01-.9 1.38c-.42.42-.82.68-1.38.9-.42.16-1.06.36-2.23.41-1.27.06-1.65.07-4.85.07s-3.58-.01-4.85-.07c-1.17-.05-1.8-.25-2.23-.41a3.7 3.7 0 01-1.38-.9 3.7 3.7 0 01-.9-1.38c-.16-.42-.36-1.06-.41-2.23C2.17 15.58 2.16 15.2 2.16 12s.01-3.58.07-4.85c.05-1.17.25-1.8.41-2.23.22-.56.48-.96.9-1.38.42-.42.82-.68 1.38-.9.42-.16 1.06-.36 2.23-.41C8.42 2.17 8.8 2.16 12 2.16zm0 3.68a6.16 6.16 0 100 12.32 6.16 6.16 0 000-12.32zm0 10.16a4 4 0 110-8 4 4 0 010 8zm6.4-10.4a1.44 1.44 0 11-2.88 0 1.44 1.44 0 012.88 0z"/></svg>
+                Instagram
+              </a>
+            {% endif %}
+            {% if group.facebook %}
+              <a href="{{ group.facebook }}" target="_blank" rel="noopener" class="flex items-center gap-3 px-6 py-4 font-bold text-white transition hover:bg-green-800">
+                <svg class="w-5 h-5 text-yellow-200 shrink-0" fill="currentColor" viewBox="0 0 24 24"><path d="M22 12a10 10 0 10-11.56 9.88v-6.99H7.9V12h2.54V9.8c0-2.5 1.49-3.89 3.78-3.89 1.09 0 2.24.2 2.24.2v2.46h-1.26c-1.24 0-1.63.77-1.63 1.56V12h2.78l-.44 2.89h-2.34v6.99A10 10 0 0022 12z"/></svg>
+                Facebook
+              </a>
+            {% endif %}
+          </div>
+        {% endif %}
+      </div>
+    </aside>
+  </div>
 </div>
 
-<div class="bg-green-700">
-    <div class="container flex flex-col justify-between py-8 md:flex-row">
-        <div class="flex flex-col md:flex-row">
-        </div>
-    </div>
-</div>
+<!-- Map -->
+<section class="bg-white">
+  <div class="container px-4 py-12 mx-auto">
+    <h2 class="mb-6 text-2xl font-black tracking-wide text-green-900 uppercase">Where they work</h2>
+    <div id="map" class="w-full overflow-hidden shadow-sm rounded-2xl" style="height: 440px;"></div>
+  </div>
+</section>
 
 {% set editCollection = "orgs" %}
 {% set editTarget = group %}
@@ -74,7 +143,7 @@ path: Volunteer Groups
     // customize the center for each trail separately
     var map = L.map('map', { fullscreenControl: true }).setView([34.20486, -118.12827], 16)
     var gl = L.mapboxGL({
-        attribution: "\u003ca href=\"https://www.maptiler.com/copyright/\" target=\"_blank\"\u003e\u0026copy; MapTiler\u003c/a\u003e \u003ca href=\"https://www.openstreetmap.org/copyright\" target=\"_blank\"\u003e\u0026copy; OpenStreetMap contributors\u003c/a\u003e",
+        attribution: "<a href=\"https://www.maptiler.com/copyright/\" target=\"_blank\">&copy; MapTiler</a> <a href=\"https://www.openstreetmap.org/copyright\" target=\"_blank\">&copy; OpenStreetMap contributors</a>",
         style: 'https://api.maptiler.com/maps/5d346e94-c6a9-4c69-a2a2-47278fa23542/style.json?key=VK9en7fqcN8VTzfv5LVe'
     }).addTo(map)
 
@@ -101,10 +170,10 @@ path: Volunteer Groups
     {% endif %}
     {% endfor %}
     {% endfor %}
-    
+
     if (markers.length === 1) {
         map.setView([markers[0].getLatLng().lat, markers[0].getLatLng().lng], 11)
-    } else {
+    } else if (markers.length > 1) {
         let group = new L.featureGroup(markers)
         map.fitBounds(group.getBounds().pad(0.5))
     }

--- a/src/volunteer-groups/group-pages.html
+++ b/src/volunteer-groups/group-pages.html
@@ -35,8 +35,8 @@ path: Volunteer Groups
     <div class="w-full">
         <div id="map" style="height: 400px; width: 100%;"></div>
     </div>
-    <div class="flex flex-col flex-grow flex-stretch">
-        <div class="flex-grow flex-shrink bg-green-700 p-7 flex-basis">
+    <div class="flex flex-col grow flex-stretch">
+        <div class="grow shrink bg-green-700 p-7 flex-basis">
             <h3 class="text-xl font-extrabold text-white uppercase">{{group.name}}</h3>
             <ul class="text-white">
                 <li><span>E-mail: <a class="text-white" href="mailto:{{ group.contactEmail }}">{{group.contactName}}</a></li>
@@ -45,7 +45,7 @@ path: Volunteer Groups
                 <li><a class="text-white underline hover:no-underline" href="{{ group.facebook }}">Facebook</a></li>
             </ul>
         </div>
-        <div class="flex-grow flex-shrink bg-green-800 p-7 flex-basis">
+        <div class="grow shrink bg-green-800 p-7 flex-basis">
             <h3 class="text-xl font-extrabold text-white uppercase">Places maintained</h3>
                 {% for groupplace in group.places %}
                 {% for place in places.places %}

--- a/src/volunteer-groups/group-pages.html
+++ b/src/volunteer-groups/group-pages.html
@@ -23,11 +23,11 @@ path: Volunteer Groups
   {% if group.photo %}
     <img class="absolute inset-0 object-cover w-full h-full" src="{{ group.photo }}" alt="{{ group.name }}">
   {% endif %}
-  <div class="absolute inset-0" style="background: linear-gradient(to top, rgba(2,80,47,0.95) 0%, rgba(2,80,47,0.55) 45%, rgba(2,80,47,0.15) 100%);"></div>
+  <div class="absolute inset-0" style="background: linear-gradient(to top, rgba(2,80,47,0.8) 0%, rgba(2,80,47,0.25) 45%, rgba(2,80,47,0) 78%);"></div>
   <div class="relative w-full">
     <div class="container px-4 pb-8 mx-auto md:pb-10">
       <p class="mb-2 text-xs font-black tracking-widest text-yellow-200 uppercase md:text-sm">Volunteer group</p>
-      <h1 class="max-w-3xl text-4xl font-black leading-none tracking-tight text-white uppercase md:text-6xl">{{ group.name }}</h1>
+      <h1 class="max-w-3xl text-2xl font-black leading-tight tracking-tight text-white uppercase md:text-4xl">{{ group.name }}</h1>
       {% if group.filters %}
         <div class="flex flex-wrap gap-2 mt-5">
           {% for groupfilter in group.filters %}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,58 +1,49 @@
+// Loaded by Tailwind v4 via `@config` in src/static/css/tailwind.css.
 module.exports = {
-  purge: {
-    mode: "all",
-    content: ["./**/*.html"],
-    options: {
-      safelist: [
-        "splide__arrow--prev",
-        "splide__arrow--next"
-      ],
-    },
-  },
+  content: ["./src/**/*.{html,njk,md}"],
   theme: {
     colors: {
-      black: '#000',
+      black: "#000",
       gray: {
-        100: '#efefef',
-        200: '#f2f2f2',
-        900: '#1F2021'
+        100: "#efefef",
+        200: "#f2f2f2",
+        900: "#1F2021",
       },
       green: {
-        300: '#92B99D',
-        400: '#59966D',
-        500: '#74A882',
-        600: '#6AA078',
-        700: '#3A724F',
-        800: '#04472B',
-        900: '#02502F'
+        300: "#92B99D",
+        400: "#59966D",
+        500: "#74A882",
+        600: "#6AA078",
+        700: "#3A724F",
+        800: "#04472B",
+        900: "#02502F",
       },
       yellow: {
-        50: '#E4FFAD', // nav highlight
-        200: '#FFE67B', // button
-        500: '#E27B38' // ticker, button
+        50: "#E4FFAD", // nav highlight
+        200: "#FFE67B", // button
+        500: "#E27B38", // ticker, button
       },
-      transparent: 'transparent',
-      white: '#fff'
+      transparent: "transparent",
+      white: "#fff",
     },
     container: {
       center: true,
       padding: {
-        DEFAULT: '2rem',
-        sm: '2rem',
-        md: '2rem',
-        lg: '3rem',
-        xl: '2rem',
-        '2xl': '3rem'
-      }
+        DEFAULT: "2rem",
+        sm: "2rem",
+        md: "2rem",
+        lg: "3rem",
+        xl: "2rem",
+        "2xl": "3rem",
+      },
     },
     fontFamily: {
-      'sans': ['Catamaran', 'sans-serif'],
-      'serif': ['Merriweather', 'serif']
+      sans: ["Catamaran", "sans-serif"],
+      serif: ["Merriweather", "serif"],
     },
     extend: {
       colors: {},
     },
   },
-  variants: {},
   plugins: [require("@tailwindcss/typography")],
 };


### PR DESCRIPTION
Upgrades the three core front-end deps to current majors, plus a small hero fix.

| Package | Before | After |
|---|---|---|
| `@11ty/eleventy` | 2.0.1 | 3.1.6 |
| `@11ty/eleventy-plugin-syntaxhighlight` | 3.0.1 | 5.0.2 |
| `alpinejs` | 2.8.2 | 3.15.12 |
| `tailwindcss` | 2.2.19 | 4.3.3 |
| `@tailwindcss/typography` | 0.3.1 | 0.5.20 |
| `autoprefixer` | 10.x | removed (v4 handles it) |

## Eleventy 2 → 3
- Removed `setDataDeepMerge` (removed in v3; deep-merge is always on).
- Bumped the syntax-highlight plugin to v5 (v3-compatible).
- Custom `/*--- ---*/` frontmatter delimiters verified still working (all pages build).

## Alpine 2 → 3
- Passthrough the v3 CDN build (`dist/cdn.min.js`).
- `navbar.html`: `x-show.transition` → `x-show` + `x-transition`; `@click.away` → `@click.outside` (both changed in v3).

## Tailwind 2 → 4
- `@tailwindcss/postcss` PostCSS plugin; dropped the old `tailwindcss()` call + autoprefixer; kept cssnano for prod.
- `tailwind.css`: `@import "tailwindcss"` + `@config` the existing JS config; **added a base rule restoring the pre-v4 default border color** (v4 defaults to `currentColor`); split the `h1` responsive `@apply` into a media query (v4 rejects that form).
- `tailwind.config.js`: v2 `purge` → `content`; dropped `variants` + the (now-removed) splide safelist; kept the custom palette, container, fonts, typography plugin.
- Template utility renames: `bg-opacity-40` → `/40` modifier; `flex-grow`/`flex-shrink` → `grow`/`shrink`.

## Build verification (automated)
- Clean `npm run build` passes, no warnings.
- Compiled CSS confirmed to include: custom colors, container centering+padding, Catamaran/Merriweather fonts, full `prose` (467 rules), `grow`/`shrink`, the hero scrim (`bg-black/40`), the `h1` responsive size, and the border-color compat rule.
- Eleventy writes all pages; Alpine dist is the v3 build.

## ⚠️ Needs visual QA in a browser (deploy preview)
Tailwind v2→v4 can regress styling in ways a build won't catch. Please spot-check on the preview:

- [ ] **Home** — hero video + 40% scrim + readable centered text + "Learn more" button (no blur).
- [ ] **Navbar** — desktop layout + mobile hamburger toggle (Alpine `@click.outside` / `x-transition`).
- [ ] **Volunteer group page** — layout columns (the `grow`/`shrink` flex boxes), map, and the "Suggest an edit" form (inputs readable, Turnstile, submit).
- [ ] **Blog post** — `prose` typography renders (headings, lists, links).
- [ ] **Borders** — tables/dividers still show the light-gray border (compat rule), not dark.
- [ ] General pass on events, newsletter, footer at mobile + desktop widths.

Also worth a click: the `/admin` (Sveltia) page still loads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)